### PR TITLE
Close outdated PRs before adding new ones

### DIFF
--- a/pkg/releaser/git.go
+++ b/pkg/releaser/git.go
@@ -129,6 +129,12 @@ func (r *Releaser) submitPR(request *source.ReleaseRequest) (string, error) {
 	tc := oauth2.NewClient(context.TODO(), ts)
 	client := github.NewClient(tc)
 
+	// Close outdated PRs before submiting new one
+	err := r.closeExistingPR(request, client)
+	if err != nil {
+		return "", err
+	}
+
 	prr := &github.NewPullRequest{
 		Title: r.getTitle(request),
 		Head:  r.getHead(request),
@@ -155,6 +161,47 @@ func (r *Releaser) submitPR(request *source.ReleaseRequest) (string, error) {
 
 	logrus.Infof("pr %q opened for releasing new version", pr.GetHTMLURL())
 	return pr.GetHTMLURL(), nil
+}
+
+func (r *Releaser) closeExistingPR(request *source.ReleaseRequest, client *github.Client) error {
+	queryString := fmt.Sprintf("is:pr is:open author:%s repo:%s/%s release new version %s",
+		request.PluginReleaseActor,
+		r.UpstreamKrewIndexRepoOwner,
+		r.UpstreamKrewIndexRepo,
+		request.PluginName,
+	)
+	closeComment := fmt.Sprintf("Closing this PR as it's outdated\n\n/close")
+
+	existentPR, _, err := client.Search.Issues(
+		context.TODO(),
+		queryString,
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+	if numPR := existentPR.GetTotal(); numPR > 0 {
+		logrus.Infof("Found %d outdated PRs, closing them before opening this new one\n",
+			numPR,
+		)
+		for _, pr := range existentPR.Issues {
+			logrus.Infof("Closing outdated PR #%d\n", pr.GetNumber())
+			_, _, err := client.PullRequests.CreateComment(
+				context.TODO(),
+				r.UpstreamKrewIndexRepoOwner,
+				r.UpstreamKrewIndexRepo,
+				pr.GetNumber(),
+				&github.PullRequestComment{
+					Body: &closeComment,
+				},
+			)
+			if err != nil {
+				logrus.Errorf("Error closing the PR %d\n", pr.GetNumber())
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (r *Releaser) getTitle(request *source.ReleaseRequest) *string {

--- a/pkg/releaser/utils.go
+++ b/pkg/releaser/utils.go
@@ -80,7 +80,7 @@ func (releaser *Releaser) Release(request *source.ReleaseRequest) (string, error
 	// Close outdated PRs before submiting new one
 	err = releaser.closeExistingPR(request, prID)
 	if err != nil {
-		return "", err
+		logrus.Warnf("Failed to close outdated PR %d", prID)
 	}
 
 	return pr, nil

--- a/pkg/releaser/utils.go
+++ b/pkg/releaser/utils.go
@@ -71,7 +71,14 @@ func (releaser *Releaser) Release(request *source.ReleaseRequest) (string, error
 	}
 
 	logrus.Info("submitting the pr")
-	pr, err := releaser.submitPR(request)
+	pr, prID, err := releaser.submitPR(request)
+	if err != nil {
+		return "", err
+	}
+
+	logrus.Info("checking if there are outdated PRs")
+	// Close outdated PRs before submiting new one
+	err = releaser.closeExistingPR(request, prID)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz ricardo.katz@gmail.com

This PR is to Close outdated PRs that might be stuck before opening new ones

I didn't tested it in prod, as I actually don't know how to trigger an action to check if its working

Fixes: #19