### PR TITLE
Fix golang version not aligned at .github/workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# ignore sensitive information
+.git
+.github
+
+# misc
+*.md
+*.sh
+*.toml
+Dockerfile
+LICENSE
+Makefile
+examples
+examples/*

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,7 +9,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.17
     - name: Run unit tests
       run: |
         go test -mod vendor ./... -cover

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.17
     - name: Run unit tests
       run: |
         go test -mod vendor ./... -cover

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM golang:1.17-alpine3.15 as builder
 WORKDIR /go/src/github.com/rajatjindal/krew-release-bot
 COPY . .
 
-RUN apk add --no-cache git
-
 RUN CGO_ENABLED=0 GOOS=linux go test -mod vendor ./... -cover
 RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor --ldflags "-s -w" -o krew-release-bot cmd/action/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,20 @@
-FROM golang:1.17.3-alpine3.14 as builder
+FROM golang:1.17-alpine3.15 as builder
 
 WORKDIR /go/src/github.com/rajatjindal/krew-release-bot
 COPY . .
 
+RUN apk add --no-cache git
+
 RUN CGO_ENABLED=0 GOOS=linux go test -mod vendor ./... -cover
 RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor --ldflags "-s -w" -o krew-release-bot cmd/action/*
 
-FROM alpine:3.14.3
+FROM alpine:3.15
 
-RUN mkdir -p /home/app
+WORKDIR /home/app
 
 # Add non root user
 RUN addgroup -S app && adduser app -S -G app
 RUN chown app /home/app
-
-WORKDIR /home/app
 
 USER app
 


### PR DESCRIPTION
-  build with `golang 1.17` and `alpine 3.15`
-  introduce `.gitignore` to prevent sensitive data being packed into docker image

### PR build

```
% go version
go version go1.17.7 darwin/amd64

% go run ./cmd/action/
krew-release-bot is a Github Action for updating plugin manifests in Krew Index repo

Usage:
  krew-release-bot [command]

Available Commands:
  action      github action for updating plugin manifests in krew-index repo
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  template    template helps validate the krew index template file without going through github actions workflow

Flags:
  -h, --help   help for krew-release-bot

Use "krew-release-bot [command] --help" for more information about a command.

% go run ./cmd/action/ help action
github action for updating plugin manifests in krew-index repo

Usage:
  krew-release-bot action [flags]

Flags:
  -h, --help   help for action
```

### Test

```
% go test ./... -cover
?   	github.com/rajatjindal/krew-release-bot/cmd/action	[no test files]
?   	github.com/rajatjindal/krew-release-bot/cmd/webhook	[no test files]
?   	github.com/rajatjindal/krew-release-bot/pkg/cicd	[no test files]
ok  	github.com/rajatjindal/krew-release-bot/pkg/cicd/circleci	0.259s	coverage: 81.5% of statements
ok  	github.com/rajatjindal/krew-release-bot/pkg/cicd/github	0.481s	coverage: 65.4% of statements
ok  	github.com/rajatjindal/krew-release-bot/pkg/cicd/travisci	0.718s	coverage: 61.5% of statements
ok  	github.com/rajatjindal/krew-release-bot/pkg/krew	0.732s	coverage: 76.5% of statements
?   	github.com/rajatjindal/krew-release-bot/pkg/releaser	[no test files]
ok  	github.com/rajatjindal/krew-release-bot/pkg/source	25.053s	coverage: 77.2% of statements
ok  	github.com/rajatjindal/krew-release-bot/pkg/source/actions	25.287s	coverage: 48.1% of statements
```