### PR TITLE
feat: add extracting version from tag for template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,33 @@
+# Test binary, build with `go test -c`
+*.test
 
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+cover.html
+
+# emacs tempfiles
+\#*
+*~
+
+# vim swap
+[._]*.s[a-w][a-z].
+[._]s[a-w][a-z].
+
+# session
+Session.vim
+
+# temporary
+.netrwhist
+*~
+
+# auto-generated tag files
+tags
+
+# IntelliJ IDE specific
+.idea
+
+# VSCode specific
+.vscode
+
+# Operating system temporary files
+.DS_Store

--- a/pkg/source/template_test.go
+++ b/pkg/source/template_test.go
@@ -113,3 +113,27 @@ func TestRenderTemplateRetry(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, 4, retries)
 }
+
+func Test_extractVersionFromTag(t *testing.T) {
+	tests := []struct {
+		name   string
+		tag    string
+		expect string
+	}{
+		{
+			name:   "should extract version from tag if defined",
+			tag:    "v0.0.2",
+			expect: "0.0.2",
+		},
+		{
+			name:   "should return tag as version if not defined in tag",
+			tag:    "no-version",
+			expect: "no-version",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.expect, extractVersionFromTag(tt.tag), "extractVersionFromTag(%v)", tt.tag)
+		})
+	}
+}


### PR DESCRIPTION
Sometimes it is necessary to use a pure version instead of a tag value, e.g. instead of `v0.0.1` simply `0.0.1`. This feature extends the data structure passed to the `.krew.yaml` template, allowing the use of `{{ .Version }}` when necessary. If the tag does not contain a version, the value of the tag is used without any modification to avoid returning an empty string.