### PR TITLE
fix: wrap the go version in single quotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: '1.20'
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v1
         with:


### PR DESCRIPTION
From https://github.com/actions/setup-go

> **Note**: Due to the peculiarities of YAML parsing, it is recommended to wrap the version in single quotation marks:
> 
> ```yaml
>   go-version: '1.20'
>  ```
>  
> The recommendation is based on the YAML parser's behavior, which interprets non-wrapped values as numbers and, in the case of version 1.20, trims it down to 1.2, which may not be very obvious.
Matching an unstable pre-release:
