### PR TITLE
feat(releaser): add support for custom krew index repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,12 @@ $ docker run -v /path/to/your/template-file.yaml:/tmp/template-file.yaml ghcr.io
 
 # Inputs for the action
 
-| Key                | Default Value          | Description                                                                          |
-| ------------------ | ---------------------- | ------------------------------------------------------------------------------------ |
-| workdir            | `env.GITHUB_WORKSPACE` | Overrides the GitHub workspace directory path                                        |
-| krew_template_file | `.krew.yaml`           | The path to template file relative to $workdir. e.g. templates/misc/plugin-name.yaml |
+| Key                            | Default Value          | Description                                                                          |
+| ------------------------------ | ---------------------- | ------------------------------------------------------------------------------------ |
+| workdir                        | `env.GITHUB_WORKSPACE` | Overrides the GitHub workspace directory path                                        |
+| krew_template_file             | `.krew.yaml`           | The path to template file relative to $workdir. e.g. templates/misc/plugin-name.yaml |
+| upstream_krew_index_repo_owner | `kubernetes-sigs`      | Overrides the GitHub owner of the Krew index, defaults to kubernetes-sigs            |
+| upstream_krew_index_repo_name  | `krew-index`           | Overrides the GitHub repository of the Krew index, defaults to krew-index            |
 
 # Limitations of krew-release-bot
 

--- a/action.yml
+++ b/action.yml
@@ -11,3 +11,11 @@ inputs:
     description: "the path to template file relative to $workdir. e.g. templates/misc/plugin-name.yaml. defaults to .krew.yaml"
   krew_plugin_release_tag:
     description: "The tag to use as version for krew plugin release. e.g. 'v5.0.0'. Defaults to parsing GITHUB_REF"
+  upstream_krew_index_repo_owner:
+    description: 'The owner of the Krew index repository'
+    required: false
+    default: kubernetes-sigs
+  upstream_krew_index_repo_name:
+    description: 'The name of the Krew index repository'
+    required: false
+    default: krew-index

--- a/pkg/cicd/circleci/circleci.go
+++ b/pkg/cicd/circleci/circleci.go
@@ -86,3 +86,23 @@ func (p *Provider) GetTemplateFile() string {
 
 	return filepath.Join(p.GetWorkDirectory(), ".krew.yaml")
 }
+
+// GetKrewIndexRepoName gets upstream_krew_index_repo_name
+func (p *Provider) GetKrewIndexRepoName() string {
+	nameInput := getInputForAction("upstream_krew_index_repo_name")
+	if nameInput != "" {
+		return nameInput
+	}
+
+	return os.Getenv("UPSTREAM_KREW_INDEX_REPO_NAME")
+}
+
+// GetKrewIndexRepoOwner gets upstream_krew_index_repo_owner
+func (p *Provider) GetKrewIndexRepoOwner() string {
+	ownerInput := getInputForAction("upstream_krew_index_repo_owner")
+	if ownerInput != "" {
+		return ownerInput
+	}
+
+	return os.Getenv("UPSTREAM_KREW_INDEX_REPO_OWNER")
+}

--- a/pkg/cicd/github/actions.go
+++ b/pkg/cicd/github/actions.go
@@ -138,3 +138,23 @@ func getReleaseForTag(client *github.Client, owner, repo, tag string) (*github.R
 
 	return release, nil
 }
+
+// GetKrewIndexRepoName gets upstream_krew_index_repo_name
+func (p *Actions) GetKrewIndexRepoName() string {
+	nameInput := getInputForAction("upstream_krew_index_repo_name")
+	if nameInput != "" {
+		return nameInput
+	}
+
+	return os.Getenv("UPSTREAM_KREW_INDEX_REPO_NAME")
+}
+
+// GetKrewIndexRepoOwner gets upstream_krew_index_repo_owner
+func (p *Actions) GetKrewIndexRepoOwner() string {
+	ownerInput := getInputForAction("upstream_krew_index_repo_owner")
+	if ownerInput != "" {
+		return ownerInput
+	}
+
+	return os.Getenv("UPSTREAM_KREW_INDEX_REPO_OWNER")
+}

--- a/pkg/cicd/provider.go
+++ b/pkg/cicd/provider.go
@@ -16,6 +16,8 @@ type Provider interface {
 	GetWorkDirectory() string
 	GetTemplateFile() string
 	IsPreRelease(owner, repo, tag string) (bool, error)
+	GetKrewIndexRepoName() string
+	GetKrewIndexRepoOwner() string
 }
 
 // GetProvider returns the CI/CD provider

--- a/pkg/cicd/travisci/travisci.go
+++ b/pkg/cicd/travisci/travisci.go
@@ -83,3 +83,23 @@ func (p *Provider) GetTemplateFile() string {
 
 	return filepath.Join(p.GetWorkDirectory(), ".krew.yaml")
 }
+
+// GetKrewIndexRepoName gets upstream_krew_index_repo_name
+func (p *Provider) GetKrewIndexRepoName() string {
+	nameInput := getInputForAction("upstream_krew_index_repo_name")
+	if nameInput != "" {
+		return nameInput
+	}
+
+	return os.Getenv("UPSTREAM_KREW_INDEX_REPO_NAME")
+}
+
+// GetKrewIndexRepoOwner gets upstream_krew_index_repo_owner
+func (p *Provider) GetKrewIndexRepoOwner() string {
+	ownerInput := getInputForAction("upstream_krew_index_repo_owner")
+	if ownerInput != "" {
+		return ownerInput
+	}
+
+	return os.Getenv("UPSTREAM_KREW_INDEX_REPO_OWNER")
+}

--- a/pkg/krew/repos.go
+++ b/pkg/krew/repos.go
@@ -3,13 +3,15 @@ package krew
 import "os"
 
 const (
-	krewIndexRepoName  = "krew-index"
-	krewIndexRepoOwner = "kubernetes-sigs"
+	krewIndexRepoName          = "krew-index"
+	krewIndexRepoOwner         = "kubernetes-sigs"
+	upstreamKrewIndexRepoName  = "UPSTREAM_KREW_INDEX_REPO_NAME"
+	upstreamKrewIndexRepoOwner = "UPSTREAM_KREW_INDEX_REPO_OWNER"
 )
 
-//GetKrewIndexRepoName returns the krew-index repo name
+// GetKrewIndexRepoName returns the krew-index repo name
 func GetKrewIndexRepoName() string {
-	override := os.Getenv("UPSTREAM_KREW_INDEX_REPO_NAME")
+	override := os.Getenv(upstreamKrewIndexRepoName)
 	if override != "" {
 		return override
 	}
@@ -17,12 +19,26 @@ func GetKrewIndexRepoName() string {
 	return krewIndexRepoName
 }
 
-//GetKrewIndexRepoOwner returns the krew-index repo owner
+// GetKrewIndexRepoOwner returns the krew-index repo owner
 func GetKrewIndexRepoOwner() string {
-	override := os.Getenv("UPSTREAM_KREW_INDEX_REPO_OWNER")
+	override := os.Getenv(upstreamKrewIndexRepoOwner)
 	if override != "" {
 		return override
 	}
 
 	return krewIndexRepoOwner
+}
+
+func SetKrewIndexRepoName(name string) string {
+	if name != "" && os.Getenv(upstreamKrewIndexRepoName) == "" {
+		return name
+	}
+	return GetKrewIndexRepoName()
+}
+
+func SetKrewIndexRepoOwner(owner string) string {
+	if owner != "" && os.Getenv(upstreamKrewIndexRepoOwner) == "" {
+		return owner
+	}
+	return GetKrewIndexRepoOwner()
 }

--- a/pkg/krew/validations.go
+++ b/pkg/krew/validations.go
@@ -8,7 +8,7 @@ import (
 	"sigs.k8s.io/krew/pkg/index/validation"
 )
 
-//ValidatePlugin validates the plugin spec
+// ValidatePlugin validates the plugin spec
 func ValidatePlugin(name, file string) error {
 	plugin, err := indexscanner.ReadPluginFile(file)
 	if err != nil {
@@ -18,7 +18,7 @@ func ValidatePlugin(name, file string) error {
 	return validation.ValidatePlugin(name, plugin)
 }
 
-//GetPluginName gets the plugin name from template .krew.yaml file
+// GetPluginName gets the plugin name from template .krew.yaml file
 func GetPluginName(spec []byte) (string, error) {
 	plugin, err := indexscanner.DecodePluginFile(bytes.NewReader(spec))
 	if err != nil {
@@ -28,7 +28,7 @@ func GetPluginName(spec []byte) (string, error) {
 	return plugin.GetName(), nil
 }
 
-//PluginFileName returns the plugin file with extension
+// PluginFileName returns the plugin file with extension
 func PluginFileName(name string) string {
 	return fmt.Sprintf("%s%s", name, ".yaml")
 }

--- a/pkg/releaser/utils.go
+++ b/pkg/releaser/utils.go
@@ -18,6 +18,10 @@ func (releaser *Releaser) Release(request *source.ReleaseRequest) (string, error
 		return "", err
 	}
 	defer os.RemoveAll(tempdir)
+	// Check krew-index inputs
+	releaser.UpstreamKrewIndexRepoName = krew.SetKrewIndexRepoName(request.KrewIndexName)
+	releaser.UpstreamKrewIndexRepoOwner = krew.SetKrewIndexRepoOwner(request.KrewIndexOwner)
+	releaser.UpstreamKrewIndexRepoCloneURL = getCloneURL(releaser.UpstreamKrewIndexRepoOwner, releaser.UpstreamKrewIndexRepoName)
 
 	logrus.Infof("will operate in tempdir %s", tempdir)
 	repo, err := releaser.cloneRepos(tempdir, request)

--- a/pkg/source/actions/action_runner.go
+++ b/pkg/source/actions/action_runner.go
@@ -63,12 +63,20 @@ func RunAction() error {
 	templateFile := provider.GetTemplateFile()
 	logrus.Infof("using template file %q", templateFile)
 
+	krewIndexOwner := provider.GetKrewIndexRepoOwner()
+	logrus.Infof("using krew-index owner %q", krewIndexOwner)
+
+	krewIndexName := provider.GetKrewIndexRepoName()
+	logrus.Infof("using krew-index name %q", krewIndexName)
+
 	releaseRequest := &source.ReleaseRequest{
 		TagName:            tag,
 		PluginOwner:        owner,
 		PluginRepo:         repo,
 		PluginReleaseActor: actor,
 		TemplateFile:       templateFile,
+		KrewIndexName:      krewIndexName,
+		KrewIndexOwner:     krewIndexOwner,
 	}
 
 	pluginName, pluginManifest, err := source.ProcessTemplate(templateFile, releaseRequest)

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -4,12 +4,12 @@ import (
 	"net/http"
 )
 
-//Source is a release source interface
+// Source is a release source interface
 type Source interface {
 	Parse(r *http.Request) (*ReleaseRequest, error)
 }
 
-//ReleaseRequest is the release request for new plugin
+// ReleaseRequest is the release request for new plugin
 type ReleaseRequest struct {
 	TagName            string `json:"tagName"`
 	PluginName         string `json:"pluginName"`
@@ -18,4 +18,6 @@ type ReleaseRequest struct {
 	PluginReleaseActor string `json:"pluginReleaseActor"`
 	TemplateFile       string `json:"templateFile"`
 	ProcessedTemplate  []byte `json:"processedTemplate"`
+	KrewIndexName      string `json:"krewIndexName"`
+	KrewIndexOwner     string `json:"krewIndexOwner"`
 }

--- a/pkg/source/template.go
+++ b/pkg/source/template.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-//InvalidPluginSpecError is invalid plugin spec error
+// InvalidPluginSpecError is invalid plugin spec error
 type InvalidPluginSpecError struct {
 	Spec string
 	err  string
@@ -33,7 +33,7 @@ func indent(spaces int, v string) string {
 	return strings.TrimSpace(pad + strings.Replace(v, "\n", "\n"+pad, -1))
 }
 
-//ProcessTemplate process the .krew.yaml template for the release request
+// ProcessTemplate process the .krew.yaml template for the release request
 func ProcessTemplate(templateFile string, values interface{}) (string, []byte, error) {
 	spec, err := RenderTemplate(templateFile, values)
 	if err != nil {
@@ -51,7 +51,7 @@ func ProcessTemplate(templateFile string, values interface{}) (string, []byte, e
 	return pluginName, spec, nil
 }
 
-//RenderTemplate process the .krew.yaml template for the release request
+// RenderTemplate process the .krew.yaml template for the release request
 func RenderTemplate(templateFile string, values interface{}) ([]byte, error) {
 	logrus.Debugf("started processing of template %s", templateFile)
 	name := path.Base(templateFile)


### PR DESCRIPTION
### Summary
This PR is to allow users to provide a custom `krew-index` repository, in case they do not wish to upload to the public `krew-index` repository. 
- https://github.com/kubernetes-sigs/krew-index

The goal is to allow users to provide the custom `krew-index` repository information through two new parameters:
- `upstream_krew_index_repo_owner`
- `upstream_krew_index_repo_name`

The GitHub Action will then determine the `default` branch that is configured for the custom `krew-index` repository, and create a PR against that `default` branch. Just in case the custom `krew-index` repository does not use the `master` branch.

This is very helpful for organizations that are hosting their own internal `krew-index` repositories, and allows them to automate their release cycles.

### Fixes
#47 

Please let me know if there is anything else I might be missing. 😄 