### PR TITLE
allow user to override release tag via actions input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,3 +9,5 @@ inputs:
     description: "Working directory, defaults to env.GITHUB_WORKSPACE"
   krew_template_file:
     description: "the path to template file relative to $workdir. e.g. templates/misc/plugin-name.yaml. defaults to .krew.yaml"
+  krew_plugin_release_tag:
+    description: "The tag to use as version for krew plugin release. e.g. 'v5.0.0'. Defaults to parsing GITHUB_REF"

--- a/pkg/cicd/circleci/circleci.go
+++ b/pkg/cicd/circleci/circleci.go
@@ -17,7 +17,12 @@ func (p *Provider) IsPreRelease(owner, repo, tag string) (bool, error) {
 
 // GetTag returns tag
 func (p *Provider) GetTag() (string, error) {
-	ref := os.Getenv("CIRCLE_TAG")
+	ref := getInputForAction("krew_plugin_release_tag")
+	if ref != "" {
+		return ref, nil
+	}
+
+	ref = os.Getenv("CIRCLE_TAG")
 	if ref == "" {
 		return "", fmt.Errorf("CIRCLE_TAG env variable not found")
 	}

--- a/pkg/cicd/circleci/circleci_test.go
+++ b/pkg/cicd/circleci/circleci_test.go
@@ -116,6 +116,14 @@ func TestGetTag(t *testing.T) {
 			},
 			expectedError: `CIRCLE_TAG env variable not found`,
 		},
+		{
+			name: "krew_plugin_release_tag is provided",
+			setup: func() {
+				os.Setenv("INPUT_KREW_PLUGIN_RELEASE_TAG", "v5.0.0")
+				os.Setenv("TRAVIS_TAG", "v1.0.0")
+			},
+			expectedTag: "v5.0.0",
+		},
 	}
 
 	p := &Provider{}

--- a/pkg/cicd/github/actions.go
+++ b/pkg/cicd/github/actions.go
@@ -48,7 +48,12 @@ func (p *Actions) getTagForCommitSha(commit string) (string, error) {
 
 // GetTag returns tag
 func (p *Actions) GetTag() (string, error) {
-	ref := os.Getenv("GITHUB_REF")
+	ref := getInputForAction("krew_plugin_release_tag")
+	if ref != "" {
+		return ref, nil
+	}
+
+	ref = os.Getenv("GITHUB_REF")
 	if ref == "" {
 		return "", fmt.Errorf("GITHUB_REF env variable not found")
 	}

--- a/pkg/cicd/github/actions_test.go
+++ b/pkg/cicd/github/actions_test.go
@@ -208,6 +208,14 @@ func TestGetTag(t *testing.T) {
 			expectedError: `failed to find the tag for the release`,
 		},
 		{
+			name: "input krew_plugin_release_tag is provided",
+			setup: func() {
+				os.Setenv("INPUT_KREW_PLUGIN_RELEASE_TAG", "v5.0.0")
+				os.Setenv("GITHUB_REF", "refs/tags/v1.0.0")
+			},
+			expectedTag: "v5.0.0",
+		},
+		{
 			name:          "GITHUB_REF is not found in env",
 			expectedError: `GITHUB_REF env variable not found`,
 		},

--- a/pkg/cicd/travisci/travisci.go
+++ b/pkg/cicd/travisci/travisci.go
@@ -17,7 +17,12 @@ func (p *Provider) IsPreRelease(owner, repo, tag string) (bool, error) {
 
 // GetTag returns tag
 func (p *Provider) GetTag() (string, error) {
-	ref := os.Getenv("TRAVIS_TAG")
+	ref := getInputForAction("krew_plugin_release_tag")
+	if ref != "" {
+		return ref, nil
+	}
+
+	ref = os.Getenv("TRAVIS_TAG")
 	if ref == "" {
 		return "", fmt.Errorf("TRAVIS_TAG env variable not found")
 	}


### PR DESCRIPTION
Allow user to override the tag used for releasing the plugin. 

For scenarios such as reported in https://github.com/rajatjindal/krew-release-bot/issues/83, the tag is created by workflow triggered on `main` branch (either with a trigger on push or manual workflow dispatch). Now even if we pass GITHUB_REF as env variable manually (that our action use), it seems like Github internally overrides that back to the original value, so the action see GITHUB_REF as `refs/tags/main`. and then when we try to fetch the tag using ListReleases api, it does not provide the GitHub commit and instead just provide `main` (which is unfortunately true for all the releases tagged from main). 

I spent a few mins thinking if allowing this will create any issues, and nothing obvious came to mind. I will sleep on this PR tonight and will merge this tomorrow if I find no concerns with this option.